### PR TITLE
Send posts to TSAF as gzip'd content

### DIFF
--- a/queue/queue.go
+++ b/queue/queue.go
@@ -95,17 +95,13 @@ func (q *Queue) sendBatch(batch opentsdb.MultiDataPoint) {
 	}
 	var buf bytes.Buffer
 	g := gzip.NewWriter(&buf)
-	_, err = g.Write(b)
-	if err != nil {
+	if _, err = g.Write(b); err != nil {
 		slog.Error(err)
+		return
 	}
-	err = g.Flush()
-	if err != nil {
+	if err = g.Close(); err != nil {
 		slog.Error(err)
-	}
-	err = g.Close()
-	if err != nil {
-		slog.Error(err)
+		return
 	}
 	req, err := http.NewRequest("POST", q.host, &buf)
 	if err != nil {

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -2,6 +2,7 @@ package queue
 
 import (
 	"bytes"
+	"compress/gzip"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -92,7 +93,27 @@ func (q *Queue) sendBatch(batch opentsdb.MultiDataPoint) {
 		// bad JSON encoding, just give up
 		return
 	}
-	resp, err := client.Post(q.host, "application/json", bytes.NewReader(b))
+	var buf bytes.Buffer
+	g := gzip.NewWriter(&buf)
+	_, err = g.Write(b)
+	if err != nil {
+		slog.Error(err)
+	}
+	err = g.Flush()
+	if err != nil {
+		slog.Error(err)
+	}
+	err = g.Close()
+	if err != nil {
+		slog.Error(err)
+	}
+	req, err := http.NewRequest("POST", q.host, bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		slog.Error(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Encoding", "gzip")
+	resp, err := client.Do(req)
 	if resp != nil && resp.Body != nil {
 		defer func() { resp.Body.Close() }()
 	}

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -107,7 +107,7 @@ func (q *Queue) sendBatch(batch opentsdb.MultiDataPoint) {
 	if err != nil {
 		slog.Error(err)
 	}
-	req, err := http.NewRequest("POST", q.host, bytes.NewReader(buf.Bytes()))
+	req, err := http.NewRequest("POST", q.host, &buf)
 	if err != nil {
 		slog.Error(err)
 	}


### PR DESCRIPTION
This will matter when stuff is going over the VPN. I have tested this and it seems to work out with the following patch applied to opentsdb: https://groups.google.com/forum/#!topic/opentsdb/JQ7azVR5x_g
