### PR TITLE
add ifspeed metric to track interface speed

### DIFF
--- a/collectors/ifstat_linux.go
+++ b/collectors/ifstat_linux.go
@@ -7,7 +7,6 @@ import (
 	"github.com/StackExchange/scollector/metadata"
 	"github.com/StackExchange/scollector/opentsdb"
 	"github.com/StackExchange/scollector/util"
-	"github.com/StackExchange/slog"
 )
 
 func init() {
@@ -78,14 +77,11 @@ func c_ifstat_linux() (opentsdb.MultiDataPoint, error) {
 		tags := opentsdb.TagSet{"iface": intf}
 
 		// Detect speed of the interface in question
-		errspeed := readLine("/sys/class/net/"+intf+"/speed", func(speed string) error {
+		readLine("/sys/class/net/"+intf+"/speed", func(speed string) error {
 			Add(&md, "linux.net.ifspeed", speed, tags, metadata.Gauge, metadata.Megabit, "")
 			Add(&md, "os.net.ifspeed", speed, tags, metadata.Gauge, metadata.Megabit, "")
 			return nil
 		})
-		if errspeed != nil {
-			slog.Info("Error reading interface speed: " + errspeed.Error())
-		}
 		for i, v := range stats {
 			if strings.HasPrefix(intf, "bond") {
 				Add(&md, "linux.net.bond."+strings.Replace(FIELDS_NET[i], ".", "_", -1), v, opentsdb.TagSet{

--- a/collectors/ifstat_linux.go
+++ b/collectors/ifstat_linux.go
@@ -75,15 +75,12 @@ func c_ifstat_linux() (opentsdb.MultiDataPoint, error) {
 		}
 		intf := m[1]
 		stats := strings.Fields(m[2])
+		tags := opentsdb.TagSet{"iface": intf}
 
 		// Detect speed of the interface in question
 		errspeed := readLine("/sys/class/net/"+intf+"/speed", func(speed string) error {
-			Add(&md, "linux.net.ifspeed", speed, opentsdb.TagSet{
-				"iface": intf},
-				metadata.Gauge, metadata.Megabit, "")
-			Add(&md, "os.net.ifspeed", speed, opentsdb.TagSet{
-				"iface": intf},
-				metadata.Gauge, metadata.Megabit, "")
+			Add(&md, "linux.net.ifspeed", speed, tags, metadata.Gauge, metadata.Megabit, "")
+			Add(&md, "os.net.ifspeed", speed, tags, metadata.Gauge, metadata.Megabit, "")
 			return nil
 		})
 		if errspeed != nil {

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -43,6 +43,7 @@ const (
 	MilliSecond         = "milliseconds"
 	V                   = "V" // Volts
 	V_10                = "tenth-Volts"
+	Megabit             = "Mbit"
 )
 
 type Metakey struct {


### PR DESCRIPTION
This change adds the linux.net.ifspeed and os.net.ifspeed metrics to track ethernet interface speed.  This can be used in other calculations (for example, capacity measurements)
