### PR TITLE
Use Win32_OperatingSystem to get windows version and caption Fixes #90

### DIFF
--- a/metadata/metadata_windows.go
+++ b/metadata/metadata_windows.go
@@ -13,37 +13,23 @@ func init() {
 	metafuncs = append(metafuncs, metaWindowsVersion, metaWindowsIfaces)
 }
 
-func queryWmi(query string, dst interface{}) error {
-	return queryWmiNamespace(query, dst, "")
-}
-
-func queryWmiNamespace(query string, dst interface{}, namespace string) error {
-	return wmi.QueryNamespace(query, dst, namespace)
-}
-
 func metaWindowsVersion() {
 	var dst []Win32_OperatingSystem
-	var q = wmi.CreateQuery(&dst, "")
-	err := queryWmi(q, &dst)
+	q := wmi.CreateQuery(&dst, "")
+	err := wmi.Query(q, &dst)
 	if err != nil {
 		slog.Error(err)
 		return
-	} else {
-		for _, v := range dst {
-			AddMeta("", nil, "version", v.Version, true)
-			AddMeta("", nil, "versionCaption", v.Caption, true)
-		}
+	}
+	for _, v := range dst {
+		AddMeta("", nil, "version", v.Version, true)
+		AddMeta("", nil, "versionCaption", v.Caption, true)
 	}
 }
 
 type Win32_OperatingSystem struct {
-	Caption         string
-	CurrentTimeZone int16
-	InstallDate     string
-	Organization    string
-	OSArchitecture  string
-	OSLanguage      int32
-	Version         string
+	Caption string
+	Version string
 }
 
 func metaWindowsIfaces() {


### PR DESCRIPTION
I had to grab the wmi functions from collectors\wmi_windows.go as they were not available in the metadata package.

Also not sure if we want to add any of the other properties from Win32_OperatingSystem as metadata
