### PR TITLE
Processes linux.go

### DIFF
--- a/collectors/processes_linux.go
+++ b/collectors/processes_linux.go
@@ -105,7 +105,30 @@ func (w *WatchedProcess) Monitor(md *opentsdb.MultiDataPoint) {
 				io = append(io, f[1])
 			}
 		}
-		Add(md, "linux.proc.cpu", stats[13], opentsdb.TagSet{"type": "user", "name": w.Name, "id": strconv.Itoa(id)}, metadata.Counter, metadata.Pct, "")
+		Add(md, "linux.proc.cpu", stats[13], opentsdb.TagSet{"type": "user", "name": w.Name, "id": strconv.Itoa(id)}, metadata.Counter, metadata.Pct,
+			"The amount of time that this process has been scheduled in user mode.")
+		Add(md, "linux.proc.cpu", stats[14], opentsdb.TagSet{"type": "system", "name": w.Name, "id": strconv.Itoa(id)}, metadata.Counter, metadata.Pct,
+			"The amount of time that this process has been scheduled in kernel mode")
+		Add(md, "linux.proc.mem.fault", stats[9], opentsdb.TagSet{"type": "minflt", "name": w.Name, "id": strconv.Itoa(id)}, metadata.Counter, metadata.Fault,
+			"The number of minor faults the process has made which have not required loading a memory page from disk.")
+		Add(md, "linux.proc.mem.fault", stats[11], opentsdb.TagSet{"type": "majflt", "name": w.Name, "id": strconv.Itoa(id)}, metadata.Counter, metadata.Fault,
+			"The number of major faults the process has made which have required loading a memory page from disk.")
+		Add(md, "linux.proc.mem.virtual", stats[22], opentsdb.TagSet{"name": w.Name, "id": strconv.Itoa(id)}, metadata.Gauge, metadata.Bytes,
+			"The virtual memory size.")
+		Add(md, "linux.proc.mem.rss", stats[23], opentsdb.TagSet{"name": w.Name, "id": strconv.Itoa(id)}, metadata.Gauge, metadata.Page,
+			"The resident set size (number of pages the process has in real memory.")
+		Add(md, "linux.proc.char_io", io[0], opentsdb.TagSet{"type": "read", "name": w.Name, "id": strconv.Itoa(id)}, metadata.Counter, metadata.Bytes,
+			"The number of bytes which this task has caused to be read from storage.  This is simply the sum of bytes which this process passed to read(2) and similar system calls. It includes things such as terminal I/O and is unaffected by whether or not actual physical disk I/O was required (the read might have been satisfied from pagecache)")
+		Add(md, "linux.proc.char_io", io[1], opentsdb.TagSet{"type": "write", "name": w.Name, "id": strconv.Itoa(id)}, metadata.Counter, metadata.Bytes,
+			"The number of bytes which this task has caused, or shall cause to be written to disk.  Similar caveats apply here as with rchar.")
+		Add(md, "linux.proc.syscall", io[2], opentsdb.TagSet{"type": "read", "name": w.Name, "id": strconv.Itoa(id)}, metadata.Counter, metadata.Syscall,
+			"An attempt to count the number of read I/O operations—that is, system calls such as read(2) and pread(2)")
+		Add(md, "linux.proc.syscall", io[3], opentsdb.TagSet{"type": "write", "name": w.Name, "id": strconv.Itoa(id)}, metadata.Counter, metadata.Syscall,
+			"Attempt to count the number of write I/O operations—that is, system calls such as write(2) and pwrite(2).")
+		Add(md, "linux.proc.io_bytes", io[4], opentsdb.TagSet{"type": "read", "name": w.Name, "id": strconv.Itoa(id)}, metadata.Counter, metadata.Bytes,
+			"An attempt to count the number of bytes which this process really did cause to be fetched from the storage layer. This is accurate for block-backed filesystems.")
+		Add(md, "linux.proc.io_bytes", io[5], opentsdb.TagSet{"type": "write", "name": w.Name, "id": strconv.Itoa(id)}, metadata.Counter, metadata.Bytes,
+			"An Attempt to count the number of bytes which this process caused to be sent to the storage layer.")
 	}
 }
 

--- a/collectors/processes_linux.go
+++ b/collectors/processes_linux.go
@@ -1,0 +1,114 @@
+// +build linux
+
+package collectors
+
+import (
+	"fmt"
+	"io/ioutil"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/StackExchange/scollector/opentsdb"
+)
+
+func init() {
+	collectors = append(collectors, &IntervalCollector{F: c_linux_processes})
+}
+
+//Will move this to collectors since this is something that should be reusable
+//IDPool is not concurrent safe
+type IDPool struct {
+	Free []int
+	Next int
+}
+
+func NewIDPool() *IDPool {
+	p := IDPool{Next: 0}
+	return &p
+}
+
+func (i *IDPool) Get() int {
+	if len(i.Free) == 0 {
+		i.Next++
+		return i.Next
+	}
+	sort.Ints(i.Free)
+	return i.Free[0]
+}
+
+func (i *IDPool) Put(v int) {
+	i.Free = append(i.Free, v)
+}
+
+type WatchedProcess struct {
+	Command   string
+	Name      string
+	Processes map[string]LinuxProcess
+	Argmatch  regexp.Regexp
+	*IDPool
+}
+
+func NewWatchedProcess(command, name, argmatch string) *WatchedProcess {
+	r := regexp.MustCompile(argmatch)
+	return &WatchedProcess{
+		Command:   command,
+		Name:      name,
+		Processes: make(map[string]LinuxProcess),
+		Argmatch:  *r,
+		IDPool:    NewIDPool(),
+	}
+}
+
+type LinuxProcess struct {
+	Pid       string
+	Command   string
+	Arguments []string
+}
+
+func GetLinuxProccesses() ([]LinuxProcess, error) {
+	files, err := ioutil.ReadDir("/proc")
+	if err != nil {
+		return nil, err
+	}
+	var pids []string
+	for _, f := range files {
+		if _, err := strconv.Atoi(f.Name()); err == nil && f.IsDir() {
+			pids = append(pids, f.Name())
+		}
+	}
+	var lps []LinuxProcess
+	for _, pid := range pids {
+		cmdline, err := ioutil.ReadFile("/proc/" + pid + "/cmdline")
+		if err != nil {
+			//Continue because the pid might not exist any more
+			continue
+		}
+		cl := strings.Split(string(cmdline), "\x00")
+		if len(cl) < 1 || len(cl[0]) == 0 {
+			continue
+		}
+		lp := LinuxProcess{
+			Pid:     pid,
+			Command: cl[0],
+		}
+		if len(cl) > 1 {
+			for _, arg := range cl[1:] {
+				lp.Arguments = append(lp.Arguments, arg)
+			}
+		}
+		lps = append(lps, lp)
+	}
+	return lps, nil
+}
+
+func c_linux_processes() (opentsdb.MultiDataPoint, error) {
+	var md opentsdb.MultiDataPoint
+	pids, err := GetLinuxProccesses()
+	if err != nil {
+		return nil, nil
+	}
+	fmt.Println(pids)
+	return md, nil
+}

--- a/main.go
+++ b/main.go
@@ -46,6 +46,8 @@ var (
 	flagDisableMetadata = flag.Bool("m", false, "Disable sending of metadata.")
 	flagVersion         = flag.Bool("version", false, `Prints the version and exits.`)
 
+	confLinuxProcess = make([]string, 0)
+
 	mains []func()
 )
 
@@ -90,6 +92,8 @@ func readConf() {
 			f(flagICMP)
 		case "vsphere":
 			f(flagVsphere)
+		case "linux_process":
+			confLinuxProcess = append(confLinuxProcess, v)
 		default:
 			if *flagDebug {
 				slog.Errorf("unknown key in %v:%v", p, i+1)
@@ -153,6 +157,11 @@ func main() {
 	}
 	if *flagFake > 0 {
 		collectors.InitFake(*flagFake)
+	}
+	if len(confLinuxProcess) > 0 {
+		if err := collectors.LinuxProcesses(confLinuxProcess); err != nil {
+			log.Fatal(err)
+		}
 	}
 	collect.Debug = *flagDebug
 	c := collectors.Search(*flagFilter)

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -36,6 +36,7 @@ const (
 	Count               = ""
 	Event               = ""
 	Entropy             = "entropy"
+	Fault               = "faults"
 	CHz                 = "CentiHertz"
 	ContextSwitch       = "context switches"
 	Interupt            = "interupts"
@@ -50,6 +51,7 @@ const (
 	Second              = "seconds"
 	Socket              = "sockets"
 	StatusCode          = "status code"
+	Syscall             = "syscalls"
 	MilliSecond         = "milliseconds"
 	V                   = "V" // Volts
 	V_10                = "tenth-Volts"


### PR DESCRIPTION
This is to replace a python script we are currently using:

```
#!/usr/bin/python
"""
Monitor Process that match the filters in etc/processes.conf
Kyle Brandt November 22, 2013
"""
import os
import sys
import time

#from collectors.lib import utils
#from collectors.etc import processes

#This will be loaded from the conf file
# This acts like a group by, metric will be tagged with the cmd and filters tags to make them unique
def main():
    COLLECTION_INTERVAL = 15  # seconds
    #http://stackoverflow.com/questions/4189123/python-how-to-get-number-of-mili-seconds-per-jiffy
    if os.sysconf(os.sysconf_names['SC_CLK_TCK']) != 100:
        print("Warning, we are assuming the clock tick is 100 which doesn't seem to be the case")

    #TODO Add aliases for these so we can just have a single string instead of two tags
    watched_conf = [["redis-server", "core.conf", "redis-core"], 
    ["redis-server", "coreml.conf", "redis-coreml"],
    ["redis-server", "gossip.conf", "redis-gossip"],
    ["redis-server", "careers.conf", "redis-careers"],
    ["ruby", "puppet", "puppet-agent"],
    ["httpd", "", "apache"],
    ["/usr/sbin/named", "", "bind"],
    ["/usr/sbin/exim", "", "exim"],
    ["haproxy-t1", "", "haproxy-t1"],
    ["haproxy-t2", "", "haproxy-t2"],
    ["haproxy-t3", "", "haproxy-t3"],
    ["haproxy-t4", "", "haproxy-t4"],
    ["haproxy-t20", "", "haproxy-t20"],
    ["/opt/realog/dash", "", "realog"],
    ["/opt/scollector/scollector", "", "scollector"],
    ["/usr/libexec/mysqld", "", "mysql"],
    ["unicorn", "worker", "unicorn-worker"],
    ["postgres", "", "postgres-db"],
    ["nginx", "", "nginx"],
    ["java", "opentsdb", "opentsdb"],
    ["/usr/sbin/keepalived", "", "keepalived"],
    ["/usr/local/bin/node", "", "node"],
    ["ruby", "patcher-update.rb", "patcher"],
    ["/opt/bosun/bosun", "", "bosun"]]

    class IDPool(object):
        def __init__(self):
            self.free = set()
            self.next = 0
        def get(self):
            if len(self.free) > 0:
                min_id = min(n for n in self.free)
                self.free.remove(min_id)
                return(min_id)
            self.next += 1
            return(self.next)
        def put(self, x):
            self.free.add(x)

    class WatchedProcess(object):
        def __init__(self, cmd, argmatch, name):
            self.cmd = cmd
            self.argmatch = argmatch
            self.name = name
            self.pids = {}
            self.idpool = IDPool()
            self.pids = {}

        def add_pid(self, pid):
            if pid not in self.pids:
                self.pids[pid] = self.idpool.get()

    watched = []
    for watch in watched_conf:
        watched.append(WatchedProcess(watch[0], watch[1], watch[2]))

    while True:
        # Gather all the data from the proc filesystem
        raw_pids = [ pid for pid in os.listdir('/proc') if pid.isdigit() ]
        # Fetch the cmd name assuming the command still exists
        for pid in raw_pids:
            try:
                cmdline = open(os.path.join('/proc', pid, 'cmdline'), 'rb').read().split('\0')
                cmd = cmdline[0]
                arguments = cmdline[1:]
                #Support regex matching instead of just substring, maybe join all the args and regex against that
                for watch in watched:
                    if watch.cmd in cmd:
                        for arg in arguments:
                            if watch.argmatch in arg:
                                watch.add_pid(pid)
                                #Don't want to add multiple times if there are multiple argument matches
                                break
            except:
                pass
        ts = int(time.time())

        for watch in watched:
            for pid in watch.pids.keys():       
                try:
                    stats = open(os.path.join('/proc', pid, 'stat'), 'rb').read().split(' ')
                    iof = open(os.path.join('/proc', pid, 'io'), 'rb').read()
                    #mstats = open(os.path.join('/proc', pid, 'statm'), 'rb').read().split(' ')
                except:
                    id = watch.pids.pop(pid)
                    watch.idpool.put(id)
                    #break since the process is gone (keyerror otherwise)
                    break
                #make io in the same format as stat
                io = [ x.split(' ')[1] for x in iof.split('\n') if len(x) > 1]
                tags = "name=%s id=%s" % (watch.name, watch.pids[pid])
                print("linux.proc.cpu %d %s type=%s %s" % (ts, stats[13], "user", tags))
                print("linux.proc.cpu %d %s type=%s %s" % (ts, stats[14], "system", tags))
                print("linux.proc.mem.fault %d %s type=%s %s" % (ts, stats[9], "minflt", tags))
                print("linux.proc.mem.fault %d %s type=%s %s" % (ts, stats[11], "majflt", tags))
                print("linux.proc.mem %d %s type=%s %s" % (ts, stats[22], "vsize", tags))
                print("linux.proc.mem %d %s type=%s %s" % (ts, stats[23], "rss", tags))
                print("linux.proc.char_io %d %s type=%s %s" % (ts, io[0], "read", tags))
                print("linux.proc.char_io %d %s type=%s %s" % (ts, io[1], "write", tags))
                print("linux.proc.syscall %d %s type=%s %s" % (ts, io[2], "read", tags))
                print("linux.proc.syscall %d %s type=%s %s" % (ts, io[3], "write", tags))
                print("linux.proc.io_bytes %d %s type=%s %s" % (ts, io[4], "read", tags))
                print("linux.proc.io_bytes %d %s type=%s %s" % (ts, io[5], "write", tags))
                #Ecluding below for now, I think the memory information from stat is fine
                #print("process.stat.mem %d %s type=%s %s" % (ts, mstats[0], "size", tags))
                #print("process.stat.mem %d %s type=%s %s" % (ts, mstats[1], "resident", tags))
                #print("process.stat.mem %d %s type=%s %s" % (ts, mstats[2], "share", tags))
                #print("process.stat.mem %d %s type=%s %s" % (ts, mstats[3], "text", tags))
                #print("process.stat.mem %d %s type=%s %s" % (ts, mstats[4], "lib", tags))
                #print("process.stat.mem %d %s type=%s %s" % (ts, mstats[5], "data", tags))
                #print("process.stat.mem %d %s type=%s %s" % (ts, mstats[6], "dirty", tags))

        sys.stdout.flush()
        time.sleep(COLLECTION_INTERVAL)

if __name__ == "__main__":
    main()
```
