### PR TITLE
Handle various ignored errors

### DIFF
--- a/collectors/dell_hw.go
+++ b/collectors/dell_hw.go
@@ -258,7 +258,7 @@ func severity(s string) int {
 
 func readOmreport(f func([]string), args ...string) {
 	args = append(args, "-fmt", "ssv")
-	util.ReadCommand(func(line string) error {
+	_ = util.ReadCommand(func(line string) error {
 		sp := strings.Split(line, ";")
 		for i, s := range sp {
 			sp[i] = clean(s)

--- a/collectors/icmp.go
+++ b/collectors/icmp.go
@@ -27,7 +27,6 @@ func ICMP(host string) {
 
 func c_icmp(host string) (opentsdb.MultiDataPoint, error) {
 	var md opentsdb.MultiDataPoint
-	var timeout = 1
 
 	p := fastping.NewPinger()
 	ra, err := net.ResolveIPAddr("ip4:icmp", host)
@@ -36,10 +35,9 @@ func c_icmp(host string) (opentsdb.MultiDataPoint, error) {
 	}
 	p.AddIPAddr(ra)
 	p.MaxRTT = time.Second * 5
+	timeout := 1
 	p.OnRecv = func(addr *net.IPAddr, t time.Duration) {
-		Add(&md, "ping.rtt", float64(t)/float64(time.Millisecond),
-			opentsdb.TagSet{"dst_host": host}, metadata.Unknown,
-			metadata.None, "")
+		Add(&md, "ping.rtt", float64(t)/float64(time.Millisecond), opentsdb.TagSet{"dst_host": host}, metadata.Unknown, metadata.None, "")
 		timeout = 0
 	}
 

--- a/collectors/ifstat_linux.go
+++ b/collectors/ifstat_linux.go
@@ -83,12 +83,14 @@ func c_ifstat_linux() (opentsdb.MultiDataPoint, error) {
 		if strings.HasPrefix(intf, "bond") || strings.HasPrefix(intf, "team") {
 			bond_string = "bond."
 		}
+
 		// Detect speed of the interface in question
-		readLine("/sys/class/net/"+intf+"/speed", func(speed string) error {
+		_ = readLine("/sys/class/net/"+intf+"/speed", func(speed string) error {
 			Add(&md, "linux.net."+bond_string+"ifspeed", speed, tags, metadata.Gauge, metadata.Megabit, "")
 			Add(&md, "os.net."+bond_string+"ifspeed", speed, tags, metadata.Gauge, metadata.Megabit, "")
 			return nil
 		})
+
 		for i, v := range stats {
 			Add(&md, "linux.net."+bond_string+strings.Replace(netFields[i].key, ".", "_", -1), v, opentsdb.TagSet{
 				"iface":     intf,

--- a/collectors/ntp_unix.go
+++ b/collectors/ntp_unix.go
@@ -53,7 +53,7 @@ func ntpUnPretty(s string) (int64, error) {
 func c_ntp_peers_unix() (opentsdb.MultiDataPoint, error) {
 	var md opentsdb.MultiDataPoint
 	const metric = "ntp."
-	util.ReadCommand(func(line string) error {
+	_ = util.ReadCommand(func(line string) error {
 		fields := strings.Fields(line)
 		if len(fields) != len(ntpNtpqPeerFields) || fields[0] == "remote" {
 			return nil

--- a/collectors/program.go
+++ b/collectors/program.go
@@ -78,21 +78,18 @@ func isExecutable(f os.FileInfo) bool {
 }
 
 func (c *ProgramCollector) Run(dpchan chan<- *opentsdb.DataPoint) {
-	if c.Interval == 0 {
-		for {
-			next := time.After(DefaultFreq)
-			if err := c.runProgram(dpchan); err != nil {
-				slog.Infoln(err)
-			}
-			<-next
-			slog.Infoln("restarting", c.Path)
+	var interval = DefaultFreq
+	if c.Interval != 0 {
+		interval = c.Interval
+	}
+
+	for {
+		next := time.After(interval)
+		if err := c.runProgram(dpchan); err != nil {
+			slog.Infoln(err)
 		}
-	} else {
-		for {
-			next := time.After(c.Interval)
-			c.runProgram(dpchan)
-			<-next
-		}
+		<-next
+		slog.Infoln("restarting", c.Path)
 	}
 }
 

--- a/metadata/metadata_dell_linux.go
+++ b/metadata/metadata_dell_linux.go
@@ -11,7 +11,7 @@ func init() {
 }
 
 func collectMetadataOmreport() {
-	util.ReadCommand(func(line string) error {
+	_ = util.ReadCommand(func(line string) error {
 		fields := strings.Split(line, ";")
 		if len(fields) != 2 {
 			return nil

--- a/metadata/metadata_linux.go
+++ b/metadata/metadata_linux.go
@@ -13,11 +13,12 @@ func init() {
 }
 
 func metaLinuxVersion() {
-	util.ReadCommand(func(line string) error {
+	_ = util.ReadCommand(func(line string) error {
 		AddMeta("", nil, "uname", line, true)
 		return nil
 	}, "uname", "-a")
-	util.ReadCommand(func(line string) error {
+
+	_ = util.ReadCommand(func(line string) error {
 		fields := strings.Fields(line)
 		hasNum := false
 		for i := 0; i < len(fields); {
@@ -39,8 +40,9 @@ func metaLinuxVersion() {
 }
 
 func metaLinuxIfaces() {
-	var iface string
-	util.ReadCommand(func(line string) error {
+	_ = util.ReadCommand(func(line string) error {
+		var iface string
+
 		sp := strings.Fields(line)
 		if len(sp) == 0 {
 			iface = ""


### PR DESCRIPTION
All ignored errors where found with the [`errcheck`](https://github.com/kisielk/errcheck) tool, I highly suggest to use this tool in your development environment. There are more errors found by errcheck that I was unsure about or didn't feel the need to ignore explicitly (such as `defer`'s and `.Close`'s).

Handle various errors that were implicitly ignored previously. Most of the changes are to explicitly ignore an error, there are a few exceptions:

`collectors/icmp.go:c_icmp` was using a [deprecated method](https://godoc.org/github.com/tatsushid/go-fastping#Pinger.AddHandler) of the `go-fastping` package. The change removed the error completely. 

`collectors/program.go:(*ProgramCollector).Run` had two separate code paths, one of them was ignoring errors. From what I could deduct it didn't seem to be intended, so I merged the two code paths into the one that handles errors.

`metadata/metadata_linux.go:metaLinuxIfaces` was using a variable defined outside of the callback function, I believe this allows it to add unintended(?) metrics if something weird happens. So I've moved it into the function.
