### PR TITLE
Add the ability to make it so tags can be added to all datapoints from t...

### DIFF
--- a/collectors/collectors.go
+++ b/collectors/collectors.go
@@ -64,6 +64,7 @@ var (
 
 	timestamp = time.Now().Unix()
 	tlock     sync.Mutex
+	AddTags   opentsdb.TagSet
 )
 
 func init() {
@@ -123,6 +124,7 @@ func AddTS(md *opentsdb.MultiDataPoint, name string, ts int64, value interface{}
 	} else if host == "" {
 		delete(tags, "host")
 	}
+	tags = AddTags.Copy().Merge(tags)
 	d := opentsdb.DataPoint{
 		Metric:    name,
 		Timestamp: ts,

--- a/collectors/program.go
+++ b/collectors/program.go
@@ -159,6 +159,7 @@ Loop:
 				dp.Tags.Merge(tags)
 			}
 		}
+		dp.Tags = AddTags.Copy().Merge(dp.Tags)
 		dpchan <- &dp
 	}
 	if err := s.Err(); err != nil {


### PR DESCRIPTION
...he CLI/conf. Fixes #153

A few things I noticed that concern me:
- opentsdb.TagSet.Merge is destructive but also returns the tagset. That threw me off, is this normal?
- Setting the hostname and and now these additional tags is duplicated in both program.go and AddTS, should this be refactored now?
